### PR TITLE
ベースパスに/homeを追加

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -10,7 +10,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory("/home"),
   routes,
 });
 


### PR DESCRIPTION
概要/説明
---
<!-- タスクの内容について記載 -->
fe_platformのURLが `xxx.com/home/* ` の形式のため、"/home"をベースパスとして設定する必要がありそう

チケット番号
---
<!-- 以下の様式で記載
- [CNJZ-XXXX](https://...) 親チケット
  - [CNJZ-XXXX](https://...) 子チケット
-->
- 


修正内容
---
<!-- コードベースでどのように対応したか記載" -->
- createWebHistory()の引数に"/home" を指定
- [参考](https://zenn.dev/azukiazusa/articles/c8d76eb56f5fd8#mode%3A-history-%3D%3E-history%3A-createwebhistory())
- 開発環境で確認する。（既に/home/* のパスでリクエストの場合、fe-platformのバケットにアクセスするようルールを設定しているので、ルール通りにトラフィックが振られるか確認）


単体テスト
---
<!-- 出力のスクリーンショットを添付 -->
