### PR TITLE
Fix/build error

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -12,7 +12,6 @@ steps:
 
         # ビルド後のファイルを確認
         echo "Checking file structure after build:"
-        ls -R home/ || true
         ls -R dist/ || true
 
         if [ "${_MODE}" != "develop" ]; then

--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -10,6 +10,11 @@ steps:
         yarn install
         yarn vite build --mode ${_MODE}
 
+        # ビルド後のファイルを確認
+        echo "Checking file structure after build:"
+        ls -R home/ || true
+        ls -R dist/ || true
+
         if [ "${_MODE}" != "develop" ]; then
           rm -f dist/assets/*.js.map
         fi

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "js-cookie": "^3.0.5",
     "quasar": "^2.17.7",
     "vue": "^3.5.13",
+    "vue-i18n": "^11.1.0",
     "vue-router": "^4.5.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,6 +174,27 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-6.3.1.tgz#1ae963dd40405450a2945408cba553e1afa3e0fb"
   integrity sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==
 
+"@intlify/core-base@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-11.1.0.tgz#bb8244042768ac96ec3536392f48278b2e3c7f61"
+  integrity sha512-5KFrnfgcv4cVWzA1RC4HqMHYEWSD/69GQU7wpKJ2l6mA6ggqEjb9NJN5VJNJvP2mU5y8MAGwXLAJXJo5sbIkMQ==
+  dependencies:
+    "@intlify/message-compiler" "11.1.0"
+    "@intlify/shared" "11.1.0"
+
+"@intlify/message-compiler@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-11.1.0.tgz#d2ceba2fa1ed1578fa791759f696b583d346d9fb"
+  integrity sha512-UuV1YwWPBNgL4uqtC1vZPHF2QtYYqVeCDIsbV6JC6Vv90UWmEiU77U7EZmNVVV7DepT83Ow5MaF1CiWI77b61w==
+  dependencies:
+    "@intlify/shared" "11.1.0"
+    source-map-js "^1.0.2"
+
+"@intlify/shared@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-11.1.0.tgz#0f9126d1be2a40642c7ac8a1eed5f23ce82d3fe4"
+  integrity sha512-DvpNSxiMrFqYMaGSRDDnQgO/L0MqNH4KWw9CUx8LRHHIdWp08En9DpmSRNpauUOxKpHAhyJJxx92BHZk9J84EQ==
+
 "@jridgewell/sourcemap-codec@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
@@ -681,7 +702,7 @@
     de-indent "^1.0.2"
     he "^1.2.0"
 
-"@vue/devtools-api@^6.6.4":
+"@vue/devtools-api@^6.5.0", "@vue/devtools-api@^6.6.4":
   version "6.6.4"
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.4.tgz#cbe97fe0162b365edc1dba80e173f90492535343"
   integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
@@ -2418,7 +2439,7 @@ sonic-boom@^1.0.2:
     atomic-sleep "^1.0.0"
     flatstr "^1.0.12"
 
-source-map-js@^1.2.0, source-map-js@^1.2.1:
+source-map-js@^1.0.2, source-map-js@^1.2.0, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -2670,6 +2691,15 @@ vscode-uri@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.8.tgz#1770938d3e72588659a172d0fd4642780083ff9f"
   integrity sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==
+
+vue-i18n@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-11.1.0.tgz#996095024da5cbb5148e602d7d88e0218ffe5fcc"
+  integrity sha512-UgtYUe99mLfo7ya5TJSsJcgJZaqIunwXjff5UA03xRry0VtgN4zIUbuoycK9/ZZQJg5Cmr6V6zq+u0H0P0hlNw==
+  dependencies:
+    "@intlify/core-base" "11.1.0"
+    "@intlify/shared" "11.1.0"
+    "@vue/devtools-api" "^6.5.0"
 
 vue-router@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
概要/説明
---
<!-- タスクの内容について記載 -->
[fe_platformのビルド・デプロイがエラーになっていた](https://console.cloud.google.com/cloud-build/builds;region=global/37916a94-de73-466b-b16e-0065fb51c033;step=0?inv=1&invt=Aboifg&project=rvp-prdct-dp-mng-dev)ので、調査したところ、vue-i18n をimportする必要があった。

チケット番号
---
<!-- 以下の様式で記載
- [CNJZ-XXXX](https://...) 親チケット
  - [CNJZ-XXXX](https://...) 子チケット
-->
- 


修正内容
---
<!-- コードベースでどのように対応したか記載" -->
- yarn add でvue-i18n を追加後、yarn installで依存関係を解決
- yarn vite build でビルドが成功することを確認

単体テスト
---
<!-- 出力のスクリーンショットを添付 -->
```sh
docker compose run --rm app yarn add vue-i18n
docker compose run --rm app yarn install
docker compose build
docker compose run --rm app yarn vite build --mode _local

[+] Building 0.0s (0/0)                                                                                                                                                                                                      docker:default
[+] Creating 1/0
 ✔ Container fe_platform-mock_server-1  Running                                                                                                                                                                                        0.0s 
[+] Building 0.0s (0/0)                                                                                                                                                                                                      docker:default
yarn run v1.22.22
$ /app/node_modules/.bin/vite build --mode _local
vite v6.0.11 building for _local...
✓ 130 modules transformed.
dist/index.html                                                              0.47 kB │ gzip:   0.30 kB
dist/assets/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ-D-x-0Q06.woff2              128.62 kB
dist/assets/gok-H7zzDkdnRel8-DQ6KAXJ69wP1tGnf4ZGhUcel5euIg-DZhiGvEA.woff2  155.28 kB
dist/assets/flUhRq6tzZclQEJ-Vdg-IuiaDsNa-Dr0goTwe.woff                     164.91 kB
dist/assets/gok-H7zzDkdnRel8-DQ6KAXJ69wP1tGnf4ZGhUcY-BpWbwl2n.woff         182.03 kB
dist/assets/index-DdumjTZW.css                                             203.20 kB │ gzip:  36.00 kB
dist/assets/index-HFMkHFun.js                                              705.20 kB │ gzip: 228.18 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 7.62s
Done in 8.63s.
```