### PR TITLE
パスワード設定画面への正しいパスに修正

### DIFF
--- a/src/pages/signin/Signin.vue
+++ b/src/pages/signin/Signin.vue
@@ -13,7 +13,7 @@ const disableStore = useDisableStore();
 const validRequired = [required()];
 const validMailAddress = [required(), email()];
 const beforeLabelWidth = "82";
-const resetPassPagePath = "/etl-tools/reset-password";
+const resetPassPagePath = "/etl-tools/password-reset";
 
 const mailAddress = ref("");
 const password = ref("");


### PR DESCRIPTION
概要/説明
---
<!-- タスクの内容について記載 -->
### 事象
サインイン画面でパスワードをリセットするために

「パスワードを忘れた場合はこちら」をクリックすると画面が表示されない

 

### 原因
[fe-platformのサインイン画面で「パスワードを忘れた場合はこちら」をクリック](https://github.com/revamp-product-dp/fe_platform/blob/4ec6ab4751ca51b8e530f62341ed21c7f6d8a8bd/src/pages/signin/Signin.vue#L16)すると、/etl-tools/reset-password でリクエストが送られるようになっている

しかし、etl-tools（frontendリポジトリ）のvue-routerで、/reset-password ではなく、/password-reset で定義されている。

結果として、返り値として期待されるコンポーネントPasswordReset/MailSend.vueが返されない


チケット番号
---
<!-- 以下の様式で記載
- [CNJZ-XXXX](https://...) 親チケット
  - [CNJZ-XXXX](https://...) 子チケット
-->
- [CNJZ-3582](https://revamp-corp.atlassian.net/browse/CNJZ-3582) 親チケット
  - [CNJZ-3512](https://revamp-corp.atlassian.net/browse/CNJZ-3512) 子チケット


修正内容
---
<!-- コードベースでどのように対応したか記載" -->
fe_platform側のSignin.vueを修正する<br>
/etl-tools/reset-password → /etl-tools/password-reset に修正する


単体テスト
---
<!-- 出力のスクリーンショットを添付 -->
