### PR TITLE
CNJZ-3633 【F】セルフアカウント作成機能（翻訳サービス未契約時の画面制御）

### DIFF
--- a/src/pages/signup/Signup.vue
+++ b/src/pages/signup/Signup.vue
@@ -1,10 +1,27 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { onBeforeMount, ref } from "vue";
+import { useRouter } from "vue-router";
+import { OrganizationApi } from "@/api-clients/common";
 import InputForm from "@/pages/signup/InputForm.vue";
 import DoneMessage from "@/pages/signup/DoneMessage.vue";
 
+const organizationApi = new OrganizationApi();
+const router = useRouter();
 const is_done = ref(false);
 const email = ref("");
+const signinPagePath = "/signin";
+
+onBeforeMount(async () => {
+  await checkContractService();
+});
+
+// 対象サービスを契約していない場合、サインイン画面に戻す
+async function checkContractService() {
+  const res = await organizationApi.getOrganizationContractServiceList();
+  const data = res.service_unit_list || []
+  if (!data.includes("TRANSLATE"))
+    router.push(signinPagePath);
+}
 
 const done = (emailValue: string) => {
   is_done.value = true;


### PR DESCRIPTION
概要/説明
---
翻訳サービス未契約時の画面制御を追加


チケット番号
---
[CNJZ-3633](https://revamp-corp.atlassian.net/browse/CNJZ-3633)
[CNJZ-3655](https://revamp-corp.atlassian.net/browse/CNJZ-3655)


修正内容
---
翻訳サービス未契約時は/signupのURLを直接使用した場合、サインイン画面に戻す処理を追加。


単体テスト
---
【サービス契約時は新規登録画面へ遷移】
![スクリーンショット 2025-05-07 094247](https://github.com/user-attachments/assets/6d15220f-b961-4599-9b15-6a36c4c5f03a)
![スクリーンショット 2025-05-07 094439](https://github.com/user-attachments/assets/90fcce3c-38fb-490c-8565-bc6335a125db)
![スクリーンショット 2025-05-07 094447](https://github.com/user-attachments/assets/db38df2f-c763-449a-a320-2d25cd2a9ff0)


【サービス未契約時はサインイン画面へ遷移】
![スクリーンショット 2025-05-07 094930](https://github.com/user-attachments/assets/8efe1a6e-f446-4865-bbd1-d1232ade7f86)
![スクリーンショット 2025-05-07 094506](https://github.com/user-attachments/assets/f71a159e-980f-4d06-9185-e1a23e428bb5)
![スクリーンショット 2025-05-07 094515](https://github.com/user-attachments/assets/84f1c18d-a849-41ee-8e20-c3b67fd75ce9)
