### PR TITLE
CNJZ-3658 fe_platformの文字が言語コードに基づいて翻訳されない

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -6,7 +6,7 @@ import zh from "@/locales/zh.json";
 // メッセージの型を定義
 type MessageSchema = typeof ja;
 
-const i18n = createI18n<[MessageSchema], "ja" | "en" | "zh">({
+const i18n = createI18n<[MessageSchema], "ja" | "en" | "zh", false>({
   legacy: false,
   locale: "ja",
   globalInjection: true,
@@ -18,3 +18,9 @@ const i18n = createI18n<[MessageSchema], "ja" | "en" | "zh">({
 });
 
 export default i18n;
+
+export class SettingLocale {
+  changeLocale(selectedLocale: "ja" | "en" | "zh"): void {
+    i18n.global.locale.value = selectedLocale;
+  }
+}

--- a/src/router/hooks.ts
+++ b/src/router/hooks.ts
@@ -1,0 +1,44 @@
+import { useAccountStore } from "@/stores/useAccountStore";
+import { SettingLocale } from "@/plugins/i18n";
+import { AccountApi } from "@/api-clients/common";
+import type { Router, RouteLocationNormalized, NavigationGuardNext } from "vue-router";
+
+// 認証チェック
+const checkAuthentication = async (
+  to: RouteLocationNormalized,
+  from: RouteLocationNormalized,
+  next: NavigationGuardNext
+) => {
+  if (to.meta.skipAuth) {
+    next();
+    return;
+  }
+
+  const api = new AccountApi();
+  try {
+    const data = await api.getAccount();
+    // アカウント情報をストアに保存
+    const account = useAccountStore();
+    account.set(data);
+    // 表示する言語をユーザ設定の言語に変更する
+    const locale = new SettingLocale();
+    if (data.lang_cd) {
+      locale.changeLocale(data.lang_cd as "ja" | "en" | "zh");
+    } else {
+      locale.changeLocale("ja");
+    }
+    next();
+  } catch (e) {
+    // セッションエラー時の処理
+    const currentPath = window.location.pathname;
+    const expiresDate = new Date();
+    expiresDate.setTime(expiresDate.getTime() + 3 * 60 * 1000);
+    document.cookie = `previousPath=${currentPath}; expires=${expiresDate.toUTCString()}; path=/`;
+
+    next({ name: "Signin" });
+  }
+};
+
+export default async (router: Router): Promise<void> => {
+  router.beforeEach(checkAuthentication);
+};

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,12 +1,10 @@
 import { createRouter, createWebHistory } from "vue-router";
+import bindHooks from "./hooks";
 import Signin from "@/pages/signin/Signin.vue";
 import Signup from "@/pages/signup/Signup.vue";
 import Home from "@/pages/home/Home.vue";
 import Error from "@/pages/error/Error.vue";
 import Users from "@/pages/users/Users.vue";
-import { useAccountStore } from "@/stores/useAccountStore";
-import { AccountApi } from "@/api-clients/common";
-import type { RouteLocationNormalized, NavigationGuardNext } from "vue-router";
 /**
  * ルートの meta 情報
  * @typedef {Object} RouteMeta
@@ -53,36 +51,6 @@ const router = createRouter({
   routes,
 });
 
-// 認証チェック
-const checkAuthentication = async (
-  to: RouteLocationNormalized,
-  from: RouteLocationNormalized,
-  next: NavigationGuardNext
-) => {
-  if (to.meta.skipAuth) {
-    next();
-    return;
-  }
-
-  const api = new AccountApi();
-  try {
-    const data = await api.getAccount();
-    // アカウント情報をストアに保存
-    const account = useAccountStore();
-    account.set(data);
-    next();
-  } catch (e) {
-    // セッションエラー時の処理
-    const currentPath = window.location.pathname;
-    const expiresDate = new Date();
-    expiresDate.setTime(expiresDate.getTime() + 3 * 60 * 1000);
-    document.cookie = `previousPath=${currentPath}; expires=${expiresDate.toUTCString()}; path=/`;
-
-    next({ name: "Signin" });
-  }
-};
-
-// ナビゲーションガード
-router.beforeEach(checkAuthentication);
+bindHooks(router);
 
 export default router;


### PR DESCRIPTION
概要/説明
---
fe_platformの文字が言語コードに基づいて翻訳されない


チケット番号
---
[CNJZ-3658](https://revamp-corp.atlassian.net/browse/CNJZ-3658)


修正内容
---
ユーザ設定の言語をもとにロケールを設定。
ファイルの切り出しも行っています。


単体テスト
---
【日本語】
![スクリーンショット 2025-05-07 152757](https://github.com/user-attachments/assets/16e56c99-ea64-47d0-a69a-d1a8a1434899)
![スクリーンショット 2025-05-07 152816](https://github.com/user-attachments/assets/35222376-3a21-4d43-8f61-27bbe40dbbd7)


【英語】
![スクリーンショット 2025-05-07 152452](https://github.com/user-attachments/assets/5e217db8-fa53-413d-9f08-abe9c7ab5ca0)
![スクリーンショット 2025-05-07 152548](https://github.com/user-attachments/assets/064293b8-34cb-431d-a3b5-6d3060b340d4)


【中国語】
![スクリーンショット 2025-05-07 152719](https://github.com/user-attachments/assets/9b135501-26a9-4d76-acaf-06cb99de9465)
![スクリーンショット 2025-05-07 152712](https://github.com/user-attachments/assets/3f324c09-815c-445a-a903-329d69f05b3c)