### PR TITLE
fix:CNJZ-4007 【脆弱性診断対応】M04: ログインを連続で失敗した時に、アカウントロックの制御を入れる

### DIFF
--- a/src/pages/signin/Signin.vue
+++ b/src/pages/signin/Signin.vue
@@ -42,8 +42,8 @@ async function signIn() {
     if (error.response?.status === 401) {
       // 401エラーはログイン失敗（残り試行回数警告含む）
       const errorMsg = error.response?.data?.msg || error.message || "";
-      // 残り試行回数が含まれている場合はそのメッセージを表示、そうでなければ通常の認証エラー
-      errorMessage = errorMsg.includes(t("notify.attempts_remaining")) ? errorMsg : t("notify.auth_error");
+      // バックエンドから多言語メッセージが返されるので、そのまま表示
+      errorMessage = errorMsg || t("notify.auth_error");
     } else if (error.response?.status === 403) {
       // 403エラー時はアカウントロックと判定してパスワードリセット画面へ遷移
       errorMessage = error.response?.data?.msg || error.message || t("notify.account_locked");


### PR DESCRIPTION
概要/説明
---
<!-- タスクの内容について記載 -->


チケット番号
---
- [CNJZ-4007](https://revamp-corp.atlassian.net/browse/CNJZ-4007) 親チケット
  - [CNJZ-XXXX](https://...) 子チケット
- 


修正内容
---
<!-- コードベースでどのように対応したか記載" -->
- 


単体テスト
---
<!-- 出力のスクリーンショットを添付 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - サインイン時の401エラー表示を改善。バックエンドから提供されたエラーメッセージを優先的に表示し、未提供の場合は汎用的な認証エラーを表示します。
  - 残り試行回数に関する不正確なメッセージ表示を廃止し、ユーザーがより正確なエラー内容を把握できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->